### PR TITLE
Name generator error handling

### DIFF
--- a/api/src/main/java/com/csiro/snomio/service/LoginService.java
+++ b/api/src/main/java/com/csiro/snomio/service/LoginService.java
@@ -1,13 +1,16 @@
 package com.csiro.snomio.service;
 
+import com.csiro.snomio.exception.AuthenticationProblem;
 import com.csiro.snomio.helper.AuthHelper;
 import com.csiro.snomio.models.ImsUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Service
 public class LoginService {
@@ -28,6 +31,12 @@ public class LoginService {
         .uri("/api/account")
         .cookie(authHelper.getImsCookieName(), cookie)
         .retrieve()
+        .onStatus(
+            HttpStatus.FORBIDDEN::equals,
+            clientResponse ->
+                Mono.error(
+                    new AuthenticationProblem(
+                        "Forbidden looking up user based on supplied cookie")))
         .bodyToMono(ImsUser.class)
         .block();
   }

--- a/api/src/main/java/com/csiro/snomio/service/NameGenerationClient.java
+++ b/api/src/main/java/com/csiro/snomio/service/NameGenerationClient.java
@@ -2,6 +2,7 @@ package com.csiro.snomio.service;
 
 import com.csiro.snomio.models.FsnAndPt;
 import com.csiro.snomio.models.NameGeneratorSpec;
+import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
@@ -9,8 +10,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
+@Log
 public class NameGenerationClient {
 
+  public static final String GENERATED_NAME_UNAVAILABLE = "Generated name unavailable";
   WebClient client;
 
   @Autowired
@@ -26,6 +29,12 @@ public class NameGenerationClient {
         .bodyValue(spec)
         .retrieve()
         .bodyToMono(FsnAndPt.class)
+        .doOnError(e -> log.severe("Name generator failed to execute with " + e.getMessage()))
+        .onErrorReturn(
+            FsnAndPt.builder()
+                .FSN(GENERATED_NAME_UNAVAILABLE)
+                .PT(GENERATED_NAME_UNAVAILABLE)
+                .build())
         .block();
   }
 }


### PR DESCRIPTION
Updated name generator integration to handle the name generator being unavailable more gracefully. Any name generator error is logged and the client is returned a name indicating name generation isn't available.